### PR TITLE
Populate sample data and provide PostgreSQL interface

### DIFF
--- a/01_database (1).sql
+++ b/01_database (1).sql
@@ -195,3 +195,51 @@ CREATE CONSTRAINT TRIGGER trg_transacoes_prevent_negative
 AFTER INSERT OR UPDATE ON volt.transacoes
 DEFERRABLE INITIALLY DEFERRED
 FOR EACH ROW EXECUTE FUNCTION volt.prevent_negative_position();
+
+-- ---------------------------------------------------------------------------
+-- Sample data
+-- ---------------------------------------------------------------------------
+
+-- Usuarios de exemplo
+INSERT INTO volt.usuarios (nome, email, role)
+SELECT 'Usuario ' || i, 'user' || i || '@example.com', 'analyst'
+FROM generate_series(1, 50) AS s(i);
+
+-- Clientes de exemplo
+INSERT INTO volt.clientes (nome, documento, tipo_documento, perfil_risco)
+SELECT 'Cliente ' || i,
+       lpad(i::text, 11, '0'),
+       'cpf',
+       'moderado'
+FROM generate_series(1, 200) AS s(i);
+
+-- Ativos de exemplo
+INSERT INTO volt.ativos (ticker, nome, classe, moeda)
+SELECT 'ATV' || i,
+       'Ativo ' || i,
+       'acao',
+       'BRL'
+FROM generate_series(1, 20) AS s(i);
+
+-- Transacoes de exemplo (1000 linhas)
+INSERT INTO volt.transacoes (cliente_id, ativo_id, tipo, quantidade, preco)
+SELECT ((i - 1) % 200) + 1 AS cliente_id,
+       ((i - 1) % 20) + 1 AS ativo_id,
+       CASE WHEN i % 2 = 0 THEN 'buy' ELSE 'sell' END AS tipo,
+       (i % 100 + 1)::NUMERIC(18,6) AS quantidade,
+       (i % 50 + 1)::NUMERIC(18,6) AS preco
+FROM generate_series(1, 1000) AS s(i);
+
+-- Consultas de exemplo (1000 linhas)
+INSERT INTO volt.consultas (usuario_id, cliente_id, titulo, descricao, status)
+SELECT ((i - 1) % 50) + 1 AS usuario_id,
+       ((i - 1) % 200) + 1 AS cliente_id,
+       'Consulta ' || i AS titulo,
+       CASE ((i - 1) % 4)
+           WHEN 0 THEN 'consulta de saldo'
+           WHEN 1 THEN 'consulta de vendas'
+           WHEN 2 THEN 'consulta de ativos'
+           ELSE 'consulta de ativos'
+       END AS descricao,
+       'aberta' AS status
+FROM generate_series(1, 1000) AS s(i);

--- a/db_interface.py
+++ b/db_interface.py
@@ -1,0 +1,31 @@
+import os
+import psycopg2
+
+
+def get_connection():
+    return psycopg2.connect(
+        host=os.getenv('PGHOST', 'localhost'),
+        port=os.getenv('PGPORT', '5432'),
+        dbname=os.getenv('PGDATABASE', 'volt_capital'),
+        user=os.getenv('PGUSER', 'postgres'),
+        password=os.getenv('PGPASSWORD', '')
+    )
+
+
+def list_consultas(limit=10):
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT consulta_id, usuario_id, cliente_id, descricao "
+        "FROM volt.consultas ORDER BY consulta_id LIMIT %s;",
+        (limit,),
+    )
+    rows = cur.fetchall()
+    cur.close()
+    conn.close()
+    return rows
+
+
+if __name__ == "__main__":
+    for row in list_consultas():
+        print(row)


### PR DESCRIPTION
## Summary
- Seed PostgreSQL schema with sample usuarios, clientes, ativos, 1000 transacoes and 1000 consultas
- Add simple Python script to query consultas from the database

## Testing
- `python -m py_compile db_interface.py`
- `python db_interface.py` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68bf8d76742c83329748e9e3d221832e