### PR TITLE
Add web interface to show database triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,14 @@ Este repositório contém o script SQL para criação do schema `volt` no Postgr
 Observações:
 - Requer extensão `citext` (permissão de superuser para `CREATE EXTENSION citext`).
 - O script usa `IF NOT EXISTS` e é idempotente.
+
+## Interface web para visualizar triggers
+
+Para demonstrar as triggers do schema `volt`, há um pequeno aplicativo Flask.
+
+1. Instale as dependências Python:
+   - `pip install flask psycopg2-binary`
+2. Ajuste as variáveis de ambiente `PGHOST`, `PGPORT`, `PGDATABASE`, `PGUSER` e `PGPASSWORD` se necessário.
+3. Execute o servidor:
+   - `python app.py`
+4. Acesse [http://localhost:5000/](http://localhost:5000/) para listar as triggers.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,29 @@
+from flask import Flask
+from db_interface import list_triggers
+
+app = Flask(__name__)
+
+@app.route("/")
+def trigger_page():
+    rows = list_triggers()
+    table_rows = "".join(
+        f"<tr><td>{table}</td><td>{name}</td><td>{timing}</td><td>{event}</td><td><pre>{stmt}</pre></td></tr>"
+        for table, name, timing, event, stmt in rows
+    )
+    html = f"""
+    <html>
+    <head><title>Triggers</title></head>
+    <body>
+        <h1>Triggers</h1>
+        <table border='1' cellpadding='5'>
+            <tr><th>Table</th><th>Name</th><th>Timing</th><th>Event</th><th>Statement</th></tr>
+            {table_rows}
+        </table>
+    </body>
+    </html>
+    """
+    return html
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/db_interface.py
+++ b/db_interface.py
@@ -26,6 +26,28 @@ def list_consultas(limit=10):
     return rows
 
 
+def list_triggers():
+    """Return metadata about triggers in schema volt."""
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        """
+        SELECT event_object_table AS table_name,
+               trigger_name,
+               action_timing,
+               event_manipulation,
+               action_statement
+        FROM information_schema.triggers
+        WHERE trigger_schema = 'volt'
+        ORDER BY event_object_table, trigger_name;
+        """
+    )
+    rows = cur.fetchall()
+    cur.close()
+    conn.close()
+    return rows
+
+
 if __name__ == "__main__":
     for row in list_consultas():
         print(row)


### PR DESCRIPTION
## Summary
- add helper to query trigger metadata from Postgres
- add Flask app that lists triggers in schema `volt`
- document how to run the web interface

## Testing
- `python -m py_compile app.py db_interface.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf908cbf408332a3b53c947124fc0b